### PR TITLE
Fixed dependency injection misconfiguration for the database

### DIFF
--- a/MiauDatabase/Common/MiauDbStatics.cs
+++ b/MiauDatabase/Common/MiauDbStatics.cs
@@ -12,13 +12,26 @@ internal static class MiauDbStatics
     /// SQLite database connection string.
     /// </summary>
     /// <remarks>Points to the current directory of the application. Has the format "Data Source=Miau.db"</remarks>
-    private static readonly string _miauDbConnectionString = "Data Source=" + Path.Combine(Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName ?? string.Empty, "Miau.db");
+    internal static readonly string MiauDbConnectionString = "Data Source=" + Path.Combine(Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName ?? string.Empty, "Miau.db");
 
     /// <summary>
-    /// Default options builder for a <see cref="MiauDbContext"/>
+    /// Default options for a <see cref="MiauDbContext"/>
     /// </summary>
-    internal static DbContextOptionsBuilder<MiauDbContext> MiauDbOptionsBuilder { get; } = new DbContextOptionsBuilder<MiauDbContext>()
+    internal static DbContextOptions<MiauDbContext> MiauDbDefaultOptions { get; } = new DbContextOptionsBuilder<MiauDbContext>()
         .UseSnakeCaseNamingConvention()     // Set column names to snake_case format
-        .UseSqlite(_miauDbConnectionString) // Database connection string
-        .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);    // Disable EF Core entity tracking - see https://docs.microsoft.com/en-us/ef/core/change-tracking/
+        .UseSqlite(MiauDbConnectionString)  // Database connection string
+        .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking) // Disable EF Core entity tracking - see https://docs.microsoft.com/en-us/ef/core/change-tracking/
+        .Options;
+
+    /// <summary>
+    /// Gets a database options builder, adds the default settings, and returns it.
+    /// </summary>
+    /// <param name="options">The database options to have the default settings applied to.</param>
+    /// <returns>A database options with the default settings applied.</returns>
+    internal static DbContextOptionsBuilder GetDefaultDbOptions(DbContextOptionsBuilder options)
+    {
+        return options.UseSnakeCaseNamingConvention()   // Set column names to snake_case format
+            .UseSqlite(MiauDbConnectionString)          // Database connection string
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);    // Disable EF Core entity tracking - see https://docs.microsoft.com/en-us/ef/core/change-tracking/
+    }
 }

--- a/MiauDatabase/Common/MiauDbStatics.cs
+++ b/MiauDatabase/Common/MiauDbStatics.cs
@@ -12,14 +12,14 @@ internal static class MiauDbStatics
     /// SQLite database connection string.
     /// </summary>
     /// <remarks>Points to the current directory of the application. Has the format "Data Source=Miau.db"</remarks>
-    internal static readonly string MiauDbConnectionString = "Data Source=" + Path.Combine(Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName ?? string.Empty, "Miau.db");
+    private static readonly string _miauDbConnectionString = "Data Source=" + Path.Combine(Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName ?? string.Empty, "Miau.db");
 
     /// <summary>
     /// Default options for a <see cref="MiauDbContext"/>
     /// </summary>
     internal static DbContextOptions<MiauDbContext> MiauDbDefaultOptions { get; } = new DbContextOptionsBuilder<MiauDbContext>()
         .UseSnakeCaseNamingConvention()     // Set column names to snake_case format
-        .UseSqlite(MiauDbConnectionString)  // Database connection string
+        .UseSqlite(_miauDbConnectionString)  // Database connection string
         .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking) // Disable EF Core entity tracking - see https://docs.microsoft.com/en-us/ef/core/change-tracking/
         .Options;
 
@@ -31,7 +31,7 @@ internal static class MiauDbStatics
     internal static DbContextOptionsBuilder GetDefaultDbOptions(DbContextOptionsBuilder options)
     {
         return options.UseSnakeCaseNamingConvention()   // Set column names to snake_case format
-            .UseSqlite(MiauDbConnectionString)          // Database connection string
+            .UseSqlite(_miauDbConnectionString)          // Database connection string
             .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);    // Disable EF Core entity tracking - see https://docs.microsoft.com/en-us/ef/core/change-tracking/
     }
 }

--- a/MiauDatabase/Design/MiauDbContextFactory.cs
+++ b/MiauDatabase/Design/MiauDbContextFactory.cs
@@ -1,0 +1,13 @@
+using MiauDatabase.Common;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace MiauDatabase.Config;
+
+/// <summary>
+/// This class is only used at design time, when EF Core is asked to perform a migration.
+/// </summary>
+internal sealed class MiauDbContextFactory : IDesignTimeDbContextFactory<MiauDbContext>
+{
+    public MiauDbContext CreateDbContext(string[] args)
+        => new(MiauDbStatics.MiauDbDefaultOptions);
+}

--- a/MiauDatabase/Extensions/IServiceCollectionExt.cs
+++ b/MiauDatabase/Extensions/IServiceCollectionExt.cs
@@ -21,12 +21,12 @@ public static class IServiceCollectionExt
         // If the database doesn't exist, create it
         if (migrate)
         {
-            using var dbContext = new MiauDbContext(MiauDbStatics.MiauDbOptionsBuilder.Options);
+            using var dbContext = new MiauDbContext(MiauDbStatics.MiauDbDefaultOptions);
             dbContext.Database.Migrate();
         }
 
         // Add the database context to the IoC
-        serviceCollection.AddDbContext<MiauDbContext>(options => options = MiauDbStatics.MiauDbOptionsBuilder);
+        serviceCollection.AddDbContext<MiauDbContext>(options => MiauDbStatics.GetDefaultDbOptions(options));
 
         return serviceCollection;
     }

--- a/MiauDatabase/MiauDbContext.cs
+++ b/MiauDatabase/MiauDbContext.cs
@@ -1,4 +1,3 @@
-using MiauDatabase.Common;
 using MiauDatabase.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,14 +19,6 @@ public sealed class MiauDbContext : DbContext
     public DbSet<PurchaseEntity> Purchases { get; init; } = null!;
     public DbSet<UserEntity> Users { get; init; } = null!;
     public DbSet<WishlistEntity> Wishlist { get; init; } = null!;
-
-    /// <summary>
-    /// Initializes a default <see cref="MiauDbContext"/> with a SQLite connection.
-    /// </summary>
-    /// <remarks>This is needed for EF Core's migration.</remarks>
-    public MiauDbContext() : this(MiauDbStatics.MiauDbOptionsBuilder.Options)
-    {
-    }
 
     /// <summary>
     /// Initializes a <see cref="MiauDbContext"/>.

--- a/MiauTests/MiauDatabase/InjectionTest.cs
+++ b/MiauTests/MiauDatabase/InjectionTest.cs
@@ -1,0 +1,29 @@
+using MiauDatabase;
+using MiauDatabase.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MiauTests.MiauDatabase;
+
+public sealed class InjectionTest
+{
+    private readonly IServiceProvider _ioc;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public InjectionTest()
+    {
+        _ioc = new ServiceCollection()
+            .AddMiauDb(false)
+            .BuildServiceProvider();
+
+        _scopeFactory = _ioc.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    [Fact]
+    internal MiauDbContext MiauDbInjectionTest()
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        // This must not throw
+        return scope.ServiceProvider.GetRequiredService<MiauDbContext>();
+    }
+}


### PR DESCRIPTION
As opções de configuração do banco de dados não estavam sendo passadas para `MiauDbContext`. Agora elas estão.
Também aproveitei para tirar o construtor padrão de `MiauDbContext`, já que estamos usando [injeção de dependência](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) no projeto.